### PR TITLE
Make a request only when called

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Epic Games status checker
 
 ### Changed
+- Make a network request only when `get_summary` is called, not on a new API instance
 
 ### Removed
 

--- a/statuscheck/services/bases/_base.py
+++ b/statuscheck/services/bases/_base.py
@@ -16,16 +16,14 @@ class BaseServiceAPI:
         module_relpath = self.__class__.__module__
         return module_relpath.rsplit(".", 1)[1]
 
-    def __init__(self):
-        self.summary = self.get_summary()
-
     def get_summary(self):
         raise NotImplementedError
 
     def _print_summary(self, verbose=False):
-        click.echo(f"Current {self.name} status: {self.summary.status.name}")
+        summary = self.get_summary()
+        click.echo(f"Current {self.name} status: {summary.status.name}")
 
-        incidents = self.summary.incidents
+        incidents = summary.incidents
         if incidents:
             click.echo("Registered events:")
             for incident in incidents:
@@ -44,6 +42,6 @@ class BaseServiceAPI:
                         else:
                             click.echo(f"    - {component.name}")
 
-        if incidents or not self.summary.status.is_ok:
+        if incidents or not summary.status.is_ok:
             click.echo()
             click.echo(f"More: {self.status_url}")

--- a/statuscheck/services/bases/_statusio.py
+++ b/statuscheck/services/bases/_statusio.py
@@ -110,4 +110,5 @@ class BaseStatusIOAPI(BaseServiceAPI):
             for incident in response_json["result"]["incidents"]
         ]
 
-        return Summary(status, components, incidents)
+        self.summary = Summary(status, components, incidents)
+        return self.summary

--- a/statuscheck/services/bases/_statuspageio.py
+++ b/statuscheck/services/bases/_statuspageio.py
@@ -104,5 +104,5 @@ class BaseStatusPageAPI(BaseServiceAPI):
             )
             for component in response_json["components"]
         ]
-
-        return Summary(status, components, incidents)
+        self.summary = Summary(status, components, incidents)
+        return self.summary

--- a/statuscheck/services/heroku.py
+++ b/statuscheck/services/heroku.py
@@ -109,4 +109,5 @@ class ServiceAPI(BaseServiceAPI):
             is_ok=worst_status in (STATUS_GREEN, STATUS_BLUE),
         )
 
-        return Summary(status, components, incidents)
+        self.summary = Summary(status, components, incidents)
+        return self.summary

--- a/statuscheck/services/salesforce.py
+++ b/statuscheck/services/salesforce.py
@@ -136,4 +136,5 @@ class ServiceAPI(BaseServiceAPI):
                 status.description = STATUS_TYPE_MAPPING[incident.status]
                 break
 
-        return Summary(status, components, incidents)
+        self.summary = Summary(status, components, incidents)
+        return self.summary

--- a/statuscheck/services/signal.py
+++ b/statuscheck/services/signal.py
@@ -54,7 +54,6 @@ class ServiceAPI(BaseServiceAPI):
                 description=STATUS_TYPE_MAPPING[STATUS_OK],
                 is_ok=True,
             )
-            return Summary(status=status, components=[], incidents=[])
         else:
             html_parser = ParseSignalStatusPage()
             html_parser.feed(response.text)
@@ -69,4 +68,5 @@ class ServiceAPI(BaseServiceAPI):
                 description=status_text,
                 is_ok=False,
             )
-            return Summary(status=status, components=[], incidents=[])
+        self.summary = Summary(status=status, components=[], incidents=[])
+        return self.summary

--- a/statuscheck/services/slack.py
+++ b/statuscheck/services/slack.py
@@ -90,4 +90,5 @@ class ServiceAPI(BaseServiceAPI):
         for incident in incidents:
             components.extend(incident.components)
 
-        return Summary(status, components, incidents)
+        self.summary = Summary(status, components, incidents)
+        return self.summary

--- a/tests/test_services/test_cloudamqp.py
+++ b/tests/test_services/test_cloudamqp.py
@@ -19,6 +19,7 @@ class TestCloudAMQP:
 
         service_name = "cloudamqp"
         service_api = get_statuscheck_api(service_name)
+        service_api.get_summary()
 
         assert service_api._module_name == service_name
         assert service_api.status_url

--- a/tests/test_services/test_docker.py
+++ b/tests/test_services/test_docker.py
@@ -16,6 +16,7 @@ class TestDocker:
 
         service_name = "docker"
         service_api = get_statuscheck_api(service_name)
+        service_api.get_summary()
 
         assert service_api._module_name == service_name
         assert service_api.status_url

--- a/tests/test_services/test_github.py
+++ b/tests/test_services/test_github.py
@@ -17,6 +17,7 @@ class TestGithub:
 
         service_name = "github"
         service_api = get_statuscheck_api(service_name)
+        service_api.get_summary()
 
         assert service_api._module_name == service_name
         assert service_api.status_url

--- a/tests/test_services/test_gitlab.py
+++ b/tests/test_services/test_gitlab.py
@@ -19,6 +19,7 @@ class TestGitlab:
 
         service_name = "gitlab"
         service_api = get_statuscheck_api(service_name)
+        service_api.get_summary()
 
         assert service_api._module_name == service_name
         assert service_api.status_url
@@ -46,6 +47,7 @@ class TestGitlab:
 
         service_name = "gitlab"
         service_api = get_statuscheck_api(service_name)
+        service_api.get_summary()
 
         assert service_api._module_name == service_name
         assert service_api.status_url

--- a/tests/test_services/test_heroku.py
+++ b/tests/test_services/test_heroku.py
@@ -20,6 +20,7 @@ class TestSlack:
 
         service_name = "heroku"
         service_api = get_statuscheck_api(service_name)
+        service_api.get_summary()
 
         assert service_api._module_name == service_name
         assert service_api.status_url
@@ -47,6 +48,7 @@ class TestSlack:
 
         service_name = "heroku"
         service_api = get_statuscheck_api(service_name)
+        service_api.get_summary()
 
         assert service_api._module_name == service_name
         assert service_api.status_url

--- a/tests/test_services/test_salesforce.py
+++ b/tests/test_services/test_salesforce.py
@@ -25,6 +25,7 @@ class TestSalesforce:
 
         service_name = "salesforce"
         service_api = get_statuscheck_api(service_name)
+        service_api.get_summary()
 
         assert service_api._module_name == service_name
         assert service_api.status_url

--- a/tests/test_services/test_slack.py
+++ b/tests/test_services/test_slack.py
@@ -17,6 +17,7 @@ class TestSlack:
 
         service_name = "slack"
         service_api = get_statuscheck_api(service_name)
+        service_api.get_summary()
 
         assert service_api._module_name == service_name
         assert service_api.status_url

--- a/tests/test_services/test_twilio.py
+++ b/tests/test_services/test_twilio.py
@@ -17,6 +17,7 @@ class TestTwilio:
 
         service_name = "twilio"
         service_api = get_statuscheck_api(service_name)
+        service_api.get_summary()
 
         assert service_api._module_name == service_name
         assert service_api.status_url

--- a/tests/test_statuscheck.py
+++ b/tests/test_statuscheck.py
@@ -29,8 +29,10 @@ def test_get_available_services():
 @pytest.mark.parametrize("service", SERVICES)
 def test_get_statuscheck_api(service):
     api = get_statuscheck_api(service)
+    summary = api.get_summary()
     assert api._module_name == service
     assert api.status_url
     assert api.service_url
     assert api.summary
+    assert api.summary == summary
     assert api.summary.as_dict()


### PR DESCRIPTION
Previously, we've made a network request the moment API was instanciated.
Now, it will be requested only when `get_summary()` is called.